### PR TITLE
make recipe compatible with autotick-bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,7 +34,7 @@ build:
         --ignore=github.com/minio/filepath
         --ignore=github.com/minio/madmin-go/v3
         --ignore=github.com/minio/pkg/v3${{ ' --ignore=github.com/mattn/go-localereader' if win else '' }}
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,14 +1,13 @@
 context:
   name: minio-client
-  tag: RELEASE.2024-11-21T17-21-54Z
-  version: ${{ tag | replace('RELEASE.', '') | replace('T', '.') | replace('-', '.') | replace('Z', '') }}
+  version: 2024-11-21T17-21-54Z
 
 package:
   name: ${{ name|lower }}
-  version: ${{ version }}
+  version: ${{ version | replace('T', '.') | replace('-', '.') | replace('Z', '') }}
 
 source:
-  - url: https://github.com/minio/mc/archive/refs/tags/${{ tag }}.tar.gz
+  - url: https://github.com/minio/mc/archive/refs/tags/RELEASE.${{ version }}.tar.gz
     sha256: dbfb5eff8a9d1a8b3b02c30596377d44478040cd19563314656f4cd009de8922
     target_directory: src
   - url: https://raw.githubusercontent.com/minio/madmin-go/refs/heads/main/LICENSE


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This should make the recipe compatible with the autotick-bot.

<!--
Please add any other relevant info below:
-->
